### PR TITLE
iOSでCreateChooserの完了/キャンセル時に終了イベントが発行されていません

### DIFF
--- a/Assets/SocialWorker/Plugins/iOS/SocialWorker.mm
+++ b/Assets/SocialWorker/Plugins/iOS/SocialWorker.mm
@@ -198,6 +198,17 @@ static const char *kResultError = "2";
 	if ([[UIDevice currentDevice].systemVersion floatValue] > 7.1f) {
         vc.popoverPresentationController.sourceView = UnityGetGLViewController().view;
 	}
+    vc.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
+        if (activityError){ 
+            UnitySendMessage(kUnitySendGameObject, kUnitySendCallback, kResultError);
+        }
+        else if (completed){
+            UnitySendMessage(kUnitySendGameObject, kUnitySendCallback, kResultSuccess);
+        }
+        else{
+            UnitySendMessage(kUnitySendGameObject, kUnitySendCallback, kResultError);
+        }
+    };
     [UnityGetGLViewController() presentViewController:vc animated:YES completion:nil];
 }
 @end


### PR DESCRIPTION
iOSでCreateChooserの時だけ終了時にイベントハンドラが呼び出されていなかったため、completionWithItemsHandlerでハンドリング出来るよう修正しました。キャンセル時に発行するResult値で適したものがなかったため取り敢えずErrorをセットしています。